### PR TITLE
Automatically find and install the `vagrant-reload` plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,13 @@ Add the following entries to your `/etc/hosts` file:
 10.1.0.203 pve3.example.com
 ```
 
-Install the following Vagrant plugins:
+Run `vagrant validate` to get the chance to install any missing plugins (notably, [`vagrant-reload`](https://github.com/aidanns/vagrant-reload), which this project requires).
 
 ```bash
-vagrant plugin install vagrant-reload   # see https://github.com/aidanns/vagrant-reload
+vagrant validate # Answer `Y` to install required plugins.
+
+# Or install the plugins manually with:
+# vagrant plugin install vagrant-reload
 ```
 
 Run `vagrant up --provider=libvirt` (or `--provider=virtualbox`) to launch the 3-node cluster.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,8 @@ storage_monitor_ips = (1..number_of_nodes).map do |n|
 end.join(';')
 
 Vagrant.configure('2') do |config|
+  config.vagrant.plugins = "vagrant-reload"
+
   config.vm.box = 'proxmox-ve-amd64'
   config.vm.provider :libvirt do |lv, config|
     lv.memory = 3*1024


### PR DESCRIPTION
Recent versions of Vagrant allow you to specify required plugins directly in the `Vagrantfile`'s configuration. I've added that here since the `vagrant-reload` plugin is required for the project. Installing the plugin this way also keeps the plugin local to the Vagrant project rather than intalling the plugin in the user's global Vagrant configuration directory.