### PR TITLE
Use standard reference to usable Vagrant base box.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure('2') do |config|
   end
 
   config.vm.define 'gateway' do |config|
-    config.vm.box = 'ubuntu-18.04-amd64'
+    config.vm.box = 'ubuntu/bionic64'
     config.vm.provider :libvirt do |lv|
       lv.memory = 512
     end

--- a/provision-gateway.sh
+++ b/provision-gateway.sh
@@ -70,8 +70,8 @@ apt-get install -y iptables iptables-persistent
 sysctl net.ipv4.ip_forward=1
 sed -i -E 's,^\s*#?\s*(net.ipv4.ip_forward=).+,\11,g' /etc/sysctl.conf
 
-# NAT through eth0.
-iptables -t nat -A POSTROUTING -s "$ip/24" ! -d "$ip/24" -o eth0 -j MASQUERADE
+# NAT through enp0s3 (formerly and traditionally eth0).
+iptables -t nat -A POSTROUTING -s "$ip/24" ! -d "$ip/24" -o enp0s3 -j MASQUERADE
 
 # load iptables rules on boot.
 iptables-save >/etc/iptables/rules.v4
@@ -89,7 +89,7 @@ cat >/etc/resolv.conf <<'EOF'
 nameserver 127.0.0.1
 EOF
 cat >/etc/dnsmasq.d/local.conf <<EOF
-interface=eth1
+interface=enp0s8
 dhcp-range=10.1.0.2,10.1.0.200,1m
 host-record=example.com,$ip
 host-record=pve1.example.com,10.1.0.201


### PR DESCRIPTION
This PR was started because when I tried to use this project, I noticed that when cloning this repo, the project seems to be a bit incomplete?

The first issue I ran into when trying it out is that the `Vagrantfile` points to a non-existent [`gateway` VM's Vagrant base box](https://github.com/rgl/proxmox-ve-cluster-vagrant/blob/36470a67a4e332cc77ceab603eb84c1563751eb2/Vagrantfile#L24). I inferred from the name that you intended to use [the `ubuntu/bionic64` base box](https://app.vagrantup.com/ubuntu/boxes/bionic64) available from the canonical Vagrant Cloud base box registry, but when I tried to use that base box, I got a `dnsmasq` configuration error citing no existing interface named `eth1`.

This is because newer versions of the Ubuntu base box use [systemd's predictable interface names](https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/), so I replaced the references to `eth0` and `eth1` with `enp0s3` and `enp0s8`, respectively, in your `provision-gateway.sh` script.

With these changes, the Vagrant `gateway` now provisions without an issue. Hope this helps!

~**NB: This PR is marked as a Work In Progress (WIP) because I'm running into another issue (the Alpine container on node `pve2` cannot access the Internet due to a failure to reach the `gateway`). As an aside, do you know why that might be?** More specifically:~ The issue described below has been resolved and is a separate issue, fixed in PR #8. More detail can be found on the [Proxmox VE Wiki's "Proxmox VE inside VirtualBox" page](https://pve.proxmox.com/wiki/Proxmox_VE_inside_VirtualBox#VirtualBox_guest_to_Proxmox_guest_communication_requires_VirtualBox_NIC_in_promiscuous_mode).

while the cluster seemed to come online without an issue, but once Vagrant tried running the container provisioning script, it hung in this infinite loop:

```
    pve2: fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
    pve2: fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
    pve2: ERROR: http://dl-cdn.alpinelinux.org/alpine/v3.10/main: temporary error (try again later)
    pve2: WARNING: Ignoring APKINDEX.00740ba1.tar.gz: No such file or directory
    pve2: 2 errors; 19 distinct packages available
    pve2: ERROR: http://dl-cdn.alpinelinux.org/alpine/v3.10/community: temporary error (try again later)
    pve2: WARNING: Ignoring APKINDEX.d8b2a6f4.tar.gz: No such file or directory
    pve2: + 
    pve2: sleep
    pve2:  5
```

To explore the issue further, I attached to the container manually and, sure enough, there's no Internet access:

```
root@pve2:~# lxc-attach -n 100 /bin/sh
~ # traceroute -q 1 -w 1 8.8.8.8
traceroute to 8.8.8.8 (8.8.8.8), 30 hops max, 46 byte packets
 1  *
 2  *
 3  *
 4  alpine-100 (10.1.0.100)  53.588 ms !H
~ # 
```

I confirmed that the container can ping the service LAN:

```
~ # ping 10.1.0.202
PING 10.1.0.202 (10.1.0.202): 56 data bytes
64 bytes from 10.1.0.202: seq=0 ttl=64 time=0.047 ms
^C
--- 10.1.0.202 ping statistics ---
1 packets transmitted, 1 packets received, 0% packet loss
round-trip min/avg/max = 0.047/0.047/0.047 ms
```

but the issue appears to be that the container cannot access the Vagrant-managed `gateway` VM at its expected adddress:

```
~ # ping 10.1.0.254
PING 10.1.0.254 (10.1.0.254): 56 data bytes
^C
--- 10.1.0.254 ping statistics ---
2 packets transmitted, 0 packets received, 100% packet loss
~ 
```

However, the Proxmox VE nodes themselves can reach the gateway:

```
root@pve2:~# ping 10.1.0.254
PING 10.1.0.254 (10.1.0.254) 56(84) bytes of data.
64 bytes from 10.1.0.254: icmp_seq=1 ttl=64 time=0.400 ms
^C
--- 10.1.0.254 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.400/0.400/0.400/0.000 ms
```