### PR TITLE
Ensure the service network's NICs are allowed to use promiscuous mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ The second node (`pve2.example.com`) is running:
   * You can login with the `root` username and `vagrant` password.
 * One Debian Live virtual machine provisioned by [provision-debian-live-virtual-machine.sh](provision-debian-live-virtual-machine.sh) and booted from the [rgl/debian-live-builder-vagrant](https://github.com/rgl/debian-live-builder-vagrant) iso.
   * You can login with the `vagrant` username and no password.
-  * This VM is also configured through [cloud-init](https://cloudinit.readthedocs.io/) as [supported by proxmox](https://pve.proxmox.com/pve-docs/pve-admin-guide.html#qm_cloud_init).
-  * **NB** This does not work in VirtualBox because it has no support for nested virtualization.
+  * This VM is also configured through [cloud-init](https://cloudinit.readthedocs.io/) as [supported by proxmox](https://pve.proxmox.com/pve-docs/pve-admin-guide.html#qm_cloud_init). (This requires VirtualBox 6.1 or later.)
 
 # Usage
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,7 +81,7 @@ Vagrant.configure('2') do |config|
           end
         end
         vb.customize ['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium', storage_disk_filename]
-        vb.customize ['modifyvm', :id, '--nicpromisc2', 'allow-vms']
+        vb.customize ['modifyvm', :id, '--nicpromisc2', 'allow-vms', '--nested-hw-virt', 'on']
       end
       config.vm.provision :shell,
         path: 'provision.sh',

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,6 +81,7 @@ Vagrant.configure('2') do |config|
           end
         end
         vb.customize ['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium', storage_disk_filename]
+        vb.customize ['modifyvm', :id, '--nicpromisc2', 'allow-vms']
       end
       config.vm.provision :shell,
         path: 'provision.sh',

--- a/provision-debian-live-virtual-machine.sh
+++ b/provision-debian-live-virtual-machine.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 set -eux
 
-dmi_sys_vendor=$(cat /sys/devices/virtual/dmi/id/sys_vendor)
-if [[ "$dmi_sys_vendor" != 'QEMU' ]]; then
-    # bail because QEMU is needed to run Virtual Machines.
-    exit 0
-fi
-
 gateway_ip=$1
 fqdn=$(hostname --fqdn)
 dn=$(hostname)
@@ -57,7 +51,7 @@ EOF
         -onboot 1 \
         -ostype l26 \
         -cpu host \
-        -cores 4 \
+        -cores 1 \
         -memory 512 \
         -cdrom $pve_storage_id:vm-$pve_id-cloudinit \
         -cicustom user=$cloud_init_user_data_volume \


### PR DESCRIPTION
This change makes it possible for containers and VMs hosted by Promox to
be accessible to other VirtualBox-hosted VMs, notably including their
Internet gateway. Without this change, Proxmox-hosted guests cannot do
basic things like update packages because they have no Internet access.

Note that this still disallows applications on the VirtualBox host
itself from reaching the containers or VMs nested inside Proxmox. For
that, the `allow-all` value should be used instead of `allow-vms`.